### PR TITLE
Fix link colors for dark mode compatibility

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -245,7 +245,19 @@ header h1 {
     color: var(--text-secondary);
 }
 
-/* Style source links to look like normal text */
+/* General link styling - compatible with dark mode */
+a {
+    color: inherit;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+a:hover {
+    color: var(--text-primary);
+    text-decoration: underline;
+}
+
+/* Style source links to look like normal text (specific override) */
 .sources-content a {
     color: inherit;
     text-decoration: none;


### PR DESCRIPTION
Fixes #2

This PR updates the CSS to make all `<a>` links compatible with dark mode:

- Add general CSS rule for all <a> tags to inherit color instead of default blue
- Remove default underlines to make links look more like normal text
- Add hover effects with lighter color and underline for better UX
- Maintain existing specific styling for source links

Generated with [Claude Code](https://claude.ai/code)